### PR TITLE
Modernize code style across all components and pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/user-event": "^13.5.0",
         "firebase": "^9.8.1",
-        "moment": "^2.29.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-firebase-hooks": "^5.0.3",
@@ -13098,14 +13097,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/user-event": "^13.5.0",
     "firebase": "^9.8.1",
-    "moment": "^2.29.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-firebase-hooks": "^5.0.3",
@@ -49,7 +48,7 @@
   "devDependencies": {
     "@testing-library/react": "^13.0.1",
     "jest-dom": "^4.0.0",
-    "react-test-renderer": "^18.0.0",
-    "react-app-rewired": "^2.2.1"
+    "react-app-rewired": "^2.2.1",
+    "react-test-renderer": "^18.0.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,3 @@
-import "./App.css";
-import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import BlogAll from "./pages/BlogAll";
@@ -13,32 +11,22 @@ import EditBlogDetail from "./pages/EditBlogDetail";
 import EditExperienceDetail from "./pages/EditExperienceDetail";
 import EditProjectDetail from "./pages/EditProjectDetail";
 
-function App() {
+export default function App() {
   return (
     <Router>
-      <div>
-        <Routes>
-          <Route exact path="/" element={<Home />} />
-          <Route path='/blog' element={<BlogAll/>} />
-          <Route path="/blog/:blogId" element={<BlogDetail/>}/>
-          <Route path="/login" element={<Login />} />
-          <Route path="/edit" element={<Edit />} />
-          <Route path="/edit/blog" element={<EditBlog />} />
-          <Route path="/edit/blog/:blogId" element={<EditBlogDetail />} />
-          <Route path="/edit/project" element={<EditProject />} />
-          <Route
-            path="/edit/project/:projectId"
-            element={<EditProjectDetail />}
-          />
-          <Route path="/edit/experience" element={<EditExperience />} />
-          <Route
-            path="/edit/experience/:experienceId"
-            element={<EditExperienceDetail />}
-          />
-        </Routes>
-      </div>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/blog" element={<BlogAll />} />
+        <Route path="/blog/:blogId" element={<BlogDetail />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/edit" element={<Edit />} />
+        <Route path="/edit/blog" element={<EditBlog />} />
+        <Route path="/edit/blog/:blogId" element={<EditBlogDetail />} />
+        <Route path="/edit/project" element={<EditProject />} />
+        <Route path="/edit/project/:projectId" element={<EditProjectDetail />} />
+        <Route path="/edit/experience" element={<EditExperience />} />
+        <Route path="/edit/experience/:experienceId" element={<EditExperienceDetail />} />
+      </Routes>
     </Router>
   );
 }
-
-export default App;

--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import SectionBlock from "../SectionBlock";
 import "./About.css";
 import headshot from "../images/headshot.jpg";
@@ -15,7 +15,7 @@ export default function About() {
   return (
     <div>
       <div
-        onClick={() => setShowAbout((prevState) => !prevState)}
+        onClick={() => setShowAbout((prev) => !prev)}
         className="sectionBlockWrapper"
       >
         <SectionBlock sectionName="ABOUT" open={showAbout} />

--- a/src/Components/DataList.js
+++ b/src/Components/DataList.js
@@ -1,109 +1,102 @@
-import React, { useState, useEffect } from "react"
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import '../blogAll.css';
-import DeleteIcon from '@mui/icons-material/Delete';
-import EditIcon from '@mui/icons-material/Edit';
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
-import { firestore } from '../firebase/config'; // Import firestore
-import { doc, updateDoc } from 'firebase/firestore'; // Import Firestore functions
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import { firestore } from "../firebase/config";
+import { doc, updateDoc } from "firebase/firestore";
+import "../blogAll.css";
 
-export default function DataList(props){
-    let { data, type, deleteFunction } = props
-    const [sortedData, setSortedData] = useState([]);
+export default function DataList({ data, type, deleteFunction }) {
+  const [sortedData, setSortedData] = useState([]);
 
-    useEffect(() => {
-        if (data) {
-            setSortedData([...data].sort((a, b) => a.order - b.order));
-        }
-    }, [data]);
+  useEffect(() => {
+    if (data) {
+      setSortedData([...data].sort((a, b) => a.order - b.order));
+    }
+  }, [data]);
 
-    const handleReorder = async (index, direction) => {
-        const newData = [...sortedData];
-        const item = newData[index];
-        const newIndex = direction === 'up' ? index - 1 : index + 1;
+  const handleReorder = async (index, direction) => {
+    const newData = [...sortedData];
+    const newIndex = direction === "up" ? index - 1 : index + 1;
 
-        if (newIndex >= 0 && newIndex < newData.length) {
-            newData.splice(index, 1);
-            newData.splice(newIndex, 0, item);
+    if (newIndex >= 0 && newIndex < newData.length) {
+      const [item] = newData.splice(index, 1);
+      newData.splice(newIndex, 0, item);
 
-            // Update order in Firestore
-            for (let i = 0; i < newData.length; i++) {
-                const docRef = doc(firestore, type, newData[i].id);
-                await updateDoc(docRef, { order: i });
-            }
+      for (let i = 0; i < newData.length; i++) {
+        await updateDoc(doc(firestore, type, newData[i].id), { order: i });
+      }
 
-            setSortedData(newData);
-        }
-    };
+      setSortedData(newData);
+    }
+  };
 
-    const output = sortedData.map((entry, index) => {
-        //Blog post also feeds to main blog page
-        let title = ""
-        let subtitle = null
-        let slug = ""
+  const output = sortedData.map((entry, index) => {
+    let title = "";
+    let subtitle = null;
+    let slug = "";
 
-        if(type==="blog" || type==="publicBlog"){
-            title = entry.title
-            subtitle = entry.date
-            slug = entry.slug
-        }
-        else if(type==="project"){
-            title = entry.name
-            slug = entry.id
+    if (type === "blog" || type === "publicBlog") {
+      title = entry.title;
+      subtitle = entry.date;
+      slug = entry.slug;
+    } else if (type === "project") {
+      title = entry.name;
+      slug = entry.id;
+    } else if (type === "experience") {
+      title = entry.position;
+      subtitle = entry.company;
+      slug = entry.id;
+    }
 
-        }
-        else if(type==="experience"){
-            title = entry.position
-            subtitle = entry.company
-            slug = entry.id
-        }
-        //the only instance in which we don't want to edit, feeds to public blog page
-
-        if(type==="publicBlog"){
-            return(           
-                <Link to={`/blog/${slug}`} className="post" key={slug}>
-                    <div className="postDiv">
-                        <div>
-                            <h1 className="title">{title}</h1>
-                            <h3>{subtitle && subtitle}</h3>
-                        </div>
-                    </div>
-                </Link>
-            )
-        }
-        //all other instances are edit instances and redirect to their respective edit page
-        return(           
-            <div className="postEdit" key={entry.id}>
-                <div className="postDiv">
-                    <div className="postContent">
-                        <h1 className="title">{title}</h1>
-                        <h3>{subtitle}</h3>
-                    </div>
-                    <div className="actionButtons">
-                        <Link to={`/edit/${type}/${entry.id}`}>
-                            <EditIcon className="actionIcon" />
-                        </Link>
-                        <DeleteIcon className="actionIcon" onClick={(e) => deleteFunction(e, entry.id, type)} />
-                        <ArrowUpwardIcon className="actionIcon" onClick={() => handleReorder(index, 'up')} />
-                        <ArrowDownwardIcon className="actionIcon" onClick={() => handleReorder(index, 'down')} />
-                    </div>
-                </div>
+    if (type === "publicBlog") {
+      return (
+        <Link to={`/blog/${slug}`} className="post" key={slug}>
+          <div className="postDiv">
+            <div>
+              <h1 className="title">{title}</h1>
+              {subtitle && <h3>{subtitle}</h3>}
             </div>
-        )
-    })
+          </div>
+        </Link>
+      );
+    }
 
-    return(
-        <div className="dataListWrapper">
-            {type !== "publicBlog" && 
-            <div className="editSectionHeader">
-                <Link to="/edit" style={{color:'white', marginBottom:'20px'}}>Back to Edit</Link>
-                <Link to={`/edit/${type}/new`} style={{color:'white', marginBottom:'20px'}}>
-                    <div className="newButton">New {type}</div>
-                </Link>
-            </div>}
-            {output}
+    return (
+      <div className="postEdit" key={entry.id}>
+        <div className="postDiv">
+          <div className="postContent">
+            <h1 className="title">{title}</h1>
+            {subtitle && <h3>{subtitle}</h3>}
+          </div>
+          <div className="actionButtons">
+            <Link to={`/edit/${type}/${entry.id}`}>
+              <EditIcon className="actionIcon" />
+            </Link>
+            <DeleteIcon className="actionIcon" onClick={(e) => deleteFunction(e, entry.id, type)} />
+            <ArrowUpwardIcon className="actionIcon" onClick={() => handleReorder(index, "up")} />
+            <ArrowDownwardIcon className="actionIcon" onClick={() => handleReorder(index, "down")} />
+          </div>
         </div>
-    )
-    
+      </div>
+    );
+  });
+
+  return (
+    <div className="dataListWrapper">
+      {type !== "publicBlog" && (
+        <div className="editSectionHeader">
+          <Link to="/edit" className="editSectionLink">
+            Back to Edit
+          </Link>
+          <Link to={`/edit/${type}/new`} className="editSectionLink">
+            <div className="newButton">New {type}</div>
+          </Link>
+        </div>
+      )}
+      {output}
+    </div>
+  );
 }

--- a/src/Components/Education/Education.css
+++ b/src/Components/Education/Education.css
@@ -1,61 +1,57 @@
-.schoolHeading{
+.schoolHeading {
     font-weight: bold;
     font-size: 32px;
     padding-top: 0px;
     margin-bottom: 0px;
-    margin-top:0px;
-}
-.schoolWrapper{
-    display:flex;
-    justify-content: space-between;
-    margin: 15px 0px 0px 0px;
-
-}
-.schoolDetail{
-    font-size:23px;
-    margin-bottom: 0px;
     margin-top: 0px;
-
 }
-.degreeWrapper{
+.schoolWrapper {
     display: flex;
     justify-content: space-between;
-    font-size:20px;
-    color:#C1C1C1;
+    margin: 15px 0px 0px 0px;
 }
-.acheivementHeading{
-    font-size:19px;
-    margin-bottom:0px;
+.schoolDetail {
+    font-size: 23px;
+    margin-bottom: 0px;
+    margin-top: 0px;
 }
-.acheivementDetail{
-    line-height: 25px;
+.degreeWrapper {
+    display: flex;
+    justify-content: space-between;
+    font-size: 20px;
+    color: #C1C1C1;
 }
-.degreeName{
+.achievementHeading {
+    font-size: 19px;
     margin-bottom: 0px;
 }
-.acheivementWrapper{
+.achievementDetail {
+    line-height: 25px;
+}
+.degreeName {
+    margin-bottom: 0px;
+}
+.achievementWrapper {
     margin-bottom: 50px;
 }
-.educationWrapper{
-    padding:0px 30px;
+.educationWrapper {
+    padding: 0px 30px;
 }
-@media only screen and (max-width: 768px){
-    .schoolWrapper,.degreeWrapper{
+@media only screen and (max-width: 768px) {
+    .schoolWrapper, .degreeWrapper {
         flex-direction: column;
-    
     }
-    .degreeName{
+    .degreeName {
         margin-top: 15px;
     }
-    .degreeDetails{
-        margin-top:10px;
+    .degreeDetails {
+        margin-top: 10px;
         font-style: italic;
     }
-    .acheivementHeading{
-
-        margin-top:0px;
+    .achievementHeading {
+        margin-top: 0px;
     }
-    .schoolHeading{
-        font-size:27px;
+    .schoolHeading {
+        font-size: 27px;
     }
 }

--- a/src/Components/Education/Education.js
+++ b/src/Components/Education/Education.js
@@ -1,38 +1,43 @@
-import React, {useState} from "react";
+import { useState } from "react";
 import SectionBlock from "../SectionBlock";
-import './Education.css'
+import "./Education.css";
 
-export default function Education(){
-    const [showEducation, setShowEducation] = useState(false)
-    return(
-        <div>
-            <div onClick={()=>setShowEducation(prevState => !prevState)} className="sectionBlockWrapper">
-                <SectionBlock sectionName="EDUCATION" open={showEducation}/>
-            </div>
-            { showEducation &&
-            <div className="educationWrapper">
-                <div className="schoolWrapper" >
-                    <h3 className="schoolHeading">Loyola Marymount University</h3>
-                    <h4 className="schoolDetail">Los Angeles, CA | May 2021</h4>
-                </div>
-                <div className="degreeWrapper">
-                    <h4 className="degreeName">B.B.A in Applied Information Management Systems 
-                        <br/>
-                        Minor in Computer Science</h4>
-                    <h4 className="degreeDetails">Magna Cum Laude | GPA: 3.89</h4>
-                </div>
-                <div className="acheivementWrapper">
-                    <h5 className="acheivementHeading">Acheivements and Awards</h5>
-                    <ul className="acheivementDetail">
-                        <li>LMU Arrupe Scholar</li>
-                        <li>Heron CBA Scholar</li>
-                        <li>John B. And Nelly Llanos Kilroy Endowed Scholar</li>
-                        <li>LMU Hackathon Mozilla State of the Internet Award</li>
-                    </ul>
-                </div>
-            </div>
-            }
-            
+export default function Education() {
+  const [showEducation, setShowEducation] = useState(false);
+
+  return (
+    <div>
+      <div
+        onClick={() => setShowEducation((prev) => !prev)}
+        className="sectionBlockWrapper"
+      >
+        <SectionBlock sectionName="EDUCATION" open={showEducation} />
+      </div>
+      {showEducation && (
+        <div className="educationWrapper">
+          <div className="schoolWrapper">
+            <h3 className="schoolHeading">Loyola Marymount University</h3>
+            <h4 className="schoolDetail">Los Angeles, CA | May 2021</h4>
+          </div>
+          <div className="degreeWrapper">
+            <h4 className="degreeName">
+              B.B.A in Applied Information Management Systems
+              <br />
+              Minor in Computer Science
+            </h4>
+            <h4 className="degreeDetails">Magna Cum Laude | GPA: 3.89</h4>
+          </div>
+          <div className="achievementWrapper">
+            <h5 className="achievementHeading">Achievements and Awards</h5>
+            <ul className="achievementDetail">
+              <li>LMU Arrupe Scholar</li>
+              <li>Heron CBA Scholar</li>
+              <li>John B. And Nelly Llanos Kilroy Endowed Scholar</li>
+              <li>LMU Hackathon Mozilla State of the Internet Award</li>
+            </ul>
+          </div>
         </div>
-    )
+      )}
+    </div>
+  );
 }

--- a/src/Components/Experience/Experience.js
+++ b/src/Components/Experience/Experience.js
@@ -1,46 +1,53 @@
-import React, {useState, useEffect} from "react"
-import SectionBlock from "../SectionBlock"
-import './Experience.css'
-import { getFirestoreCollection } from "../../dbHelpers"
-import moment from "moment"
+import { useState, useEffect } from "react";
+import SectionBlock from "../SectionBlock";
+import { getFirestoreCollection } from "../../dbHelpers";
+import "./Experience.css";
 
-export default function Experience(){
-    const [showExpereince, setShowExperience] = useState(false)
-    const [expData, setExpData] = useState()
-    const [, setLoading] = useState(false)
-    
-    useEffect(() => {
-        setLoading(true)
-        getFirestoreCollection("experience", setExpData, setLoading)
-      }, [])
+const formatMonth = (dateStr) =>
+  new Intl.DateTimeFormat("en-US", { month: "short", year: "numeric", timeZone: "UTC" }).format(
+    new Date(dateStr)
+  );
 
-      const sortedExpData = expData?.sort((a,b) => {
-        return new Date(b.startDate) - new Date(a.startDate)
-    })
- 
-    const experiences = sortedExpData?.map(exp => {
-        const formattedStartDate = moment(exp.startDate).format('MMM YYYY')
-        const formattedEndDate = exp.endDate && moment(exp.endDate).format('MMM YYYY')
-        return (
-            <div key = {exp.id} className="expBlockWrapper" >
-                <h3 className="expPosition">{exp.position}</h3>
-                <h4 className="expCompany">{exp.company}</h4>
-                <h4 className="expDetail">{exp.location} | {formattedStartDate} - {exp.endDate ? formattedEndDate : 'Present'} {exp.seasonal && '(seasonal)'}</h4>
-                <ul className="expDescription">
-                    {exp.description.map( (bullet, index) => <li key={index} className="expDescriptionBullet"> {bullet}</li> )}
-                </ul>
-            </div>
-        )
-   })
-    return(
-        <div>
-            <div onClick={()=>setShowExperience(prevState => !prevState)} className="sectionBlockWrapper">
-                <SectionBlock sectionName="EXPERIENCE" open={showExpereince}/>
-            </div>
-            {
-            showExpereince && experiences
-            }
-        </div>
-    )
+export default function Experience() {
+  const [showExperience, setShowExperience] = useState(false);
+  const [expData, setExpData] = useState();
+  const [, setLoading] = useState(false);
 
+  useEffect(() => {
+    setLoading(true);
+    getFirestoreCollection("experience", setExpData, setLoading);
+  }, []);
+
+  const sortedExpData = expData?.sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+
+  const experiences = sortedExpData?.map((exp) => (
+    <div key={exp.id} className="expBlockWrapper">
+      <h3 className="expPosition">{exp.position}</h3>
+      <h4 className="expCompany">{exp.company}</h4>
+      <h4 className="expDetail">
+        {exp.location} | {formatMonth(exp.startDate)} -{" "}
+        {exp.endDate ? formatMonth(exp.endDate) : "Present"}{" "}
+        {exp.seasonal && "(seasonal)"}
+      </h4>
+      <ul className="expDescription">
+        {exp.description.map((bullet, index) => (
+          <li key={index} className="expDescriptionBullet">
+            {bullet}
+          </li>
+        ))}
+      </ul>
+    </div>
+  ));
+
+  return (
+    <div>
+      <div
+        onClick={() => setShowExperience((prev) => !prev)}
+        className="sectionBlockWrapper"
+      >
+        <SectionBlock sectionName="EXPERIENCE" open={showExperience} />
+      </div>
+      {showExperience && experiences}
+    </div>
+  );
 }

--- a/src/Components/Footer/Footer.js
+++ b/src/Components/Footer/Footer.js
@@ -1,28 +1,26 @@
-import React from "react";
-import github from "../images/github.png"
-import Linkedin from "../images/Linkedin.png"
-import Mail from "../images/Mail.png"
-import Twitter from "../images/Twitter.png"
-import './Footer.css'
+import github from "../images/github.png";
+import Linkedin from "../images/Linkedin.png";
+import Mail from "../images/Mail.png";
+import Twitter from "../images/Twitter.png";
+import "./Footer.css";
 
-export default function Footer(){
+const LINKS = [
+  { href: "https://github.com/mikebranc/", src: github, alt: "GitHub icon" },
+  { href: "https://www.linkedin.com/in/mbranconier/", src: Linkedin, alt: "LinkedIn icon" },
+  { href: "mailto:michaelbranconier@gmail.com", src: Mail, alt: "Mail icon" },
+  { href: "https://twitter.com/mike_branc?", src: Twitter, alt: "Twitter icon" },
+];
 
-    return(
-        <div className="footerWrapper">
-            <div className="footerLinkWrapper">
-                <a className="footerLink" href="https://github.com/mikebranc/" target='_blank' rel='noreferrer noopener'>
-                    <img className="footerImg" src={github} alt="github icon"/>
-                </a>
-                <a className="footerLink" href="https://www.linkedin.com/in/mbranconier/" target='_blank' rel='noreferrer noopener'>
-                    <img className="footerImg" src={Linkedin} alt="Linkedin Icon"/>
-                </a>
-                <a className="footerLink" href="mailto:michaelbranconier@gmail.com" target='_blank' rel='noreferrer noopener'>
-                    <img className="footerImg" src={Mail} alt="Mail Icon"/>
-                </a>
-                <a className="footerLink" href="https://twitter.com/mike_branc?" target='_blank' rel='noreferrer noopener'>
-                    <img className="footerImg" src={Twitter} alt="Twitter Icon"/>
-                </a>
-            </div>
-        </div>
-    )
+export default function Footer() {
+  return (
+    <div className="footerWrapper">
+      <div className="footerLinkWrapper">
+        {LINKS.map(({ href, src, alt }) => (
+          <a key={href} className="footerLink" href={href} target="_blank" rel="noreferrer noopener">
+            <img className="footerImg" src={src} alt={alt} />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -1,19 +1,25 @@
-import React from "react";
-import {Link} from "react-router-dom"
-import "../styles.css"
+import { Link } from "react-router-dom";
+import "../styles.css";
 
 export default function Navbar() {
-    return (
-        <nav className="navStyle">
-            <Link to="/" id ="nameLink" className="navLink">Michael Branconier</Link>
-            <div className="navLinkWrapper">
-                <Link to="/blog" className="navLink">
-                    Blog
-                </Link>
-                <a href="https://summitandshark.com/?utm_source=personal-site&utm_medium=navigation&utm_campaign=consulting-link" className="navLink" target='_blank' rel="noopener noreferrer">
-                    Consulting
-                </a>
-            </div>
-        </nav>
-    );
+  return (
+    <nav className="navStyle">
+      <Link to="/" id="nameLink" className="navLink">
+        Michael Branconier
+      </Link>
+      <div className="navLinkWrapper">
+        <Link to="/blog" className="navLink">
+          Blog
+        </Link>
+        <a
+          href="https://summitandshark.com/?utm_source=personal-site&utm_medium=navigation&utm_campaign=consulting-link"
+          className="navLink"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Consulting
+        </a>
+      </div>
+    </nav>
+  );
 }

--- a/src/Components/Projects/Projects.js
+++ b/src/Components/Projects/Projects.js
@@ -1,56 +1,61 @@
-import React, {useState, useEffect} from 'react';
-import github from '../images/github.png'
-import './Projects.css';
-import SectionBlock from '../SectionBlock';
-import { getFirestoreCollection } from "../../dbHelpers"
+import { useState, useEffect } from "react";
+import github from "../images/github.png";
+import SectionBlock from "../SectionBlock";
+import { getFirestoreCollection } from "../../dbHelpers";
+import "./Projects.css";
 
-export default function Projects(){
-    const [showProjects, setShowProjects] = useState(false)
-    const [projData, setProjData] = useState()
-    const [, setLoading] = useState(false)
+export default function Projects() {
+  const [showProjects, setShowProjects] = useState(false);
+  const [projData, setProjData] = useState();
+  const [, setLoading] = useState(false);
 
-    useEffect(() => {
-        setLoading(true)
-        getFirestoreCollection("project", setProjData, setLoading)
-      }, [])
+  useEffect(() => {
+    setLoading(true);
+    getFirestoreCollection("project", setProjData, setLoading);
+  }, []);
 
-      const sortedProjData = projData
-        ?.filter(project => !project.hidden)
-        ?.sort((a,b) => a.order - b.order)
+  const sortedProjData = projData
+    ?.filter((project) => !project.hidden)
+    ?.sort((a, b) => a.order - b.order);
 
-    const projectInfo = sortedProjData?.map((project) =>{
-        return(  
-            <a className="projectLinkBlock" href={project.link} key ={project.id} target="_blank" rel="noopener noreferrer">
-                <div className="projectWrapper" >
-                    <div className="projectHead">
-                        <h3 className="projectName">{project.name}</h3>
-                        {
-                            project.githubLink && (
-                                <a href={project.githubLink} target="_blank" rel="noopener noreferrer">
-                                    <img className="projectGithubLink" src={github} alt="github Icon" />
-                                </a> 
-                            )
-                        }
-                    </div>
-                    <p className="projectDescription">{project.description}</p>
-                    <div className="projectSkillWrapper">
-                        {project.skills.map((skill, index) => <span key ={index} className="projectSkill">{skill}</span>)}
-                    </div>
-                </div>
+  const projectInfo = sortedProjData?.map((project) => (
+    <a
+      className="projectLinkBlock"
+      href={project.link}
+      key={project.id}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <div className="projectWrapper">
+        <div className="projectHead">
+          <h3 className="projectName">{project.name}</h3>
+          {project.githubLink && (
+            <a href={project.githubLink} target="_blank" rel="noopener noreferrer">
+              <img className="projectGithubLink" src={github} alt="github Icon" />
             </a>
-        )
-    })
-    return(
-        <div>
-            <div onClick={()=>setShowProjects(prevState => !prevState)} className="sectionBlockWrapper">
-                <SectionBlock sectionName="PROJECTS" open={showProjects}/>
-            </div>
-            {showProjects && (
-                <div className="projectSectionGrid">
-                 {projectInfo}
-                </div>
-            )}
+          )}
         </div>
-        
-    )
+        <p className="projectDescription">{project.description}</p>
+        <div className="projectSkillWrapper">
+          {project.skills.map((skill, index) => (
+            <span key={index} className="projectSkill">
+              {skill}
+            </span>
+          ))}
+        </div>
+      </div>
+    </a>
+  ));
+
+  return (
+    <div>
+      <div
+        onClick={() => setShowProjects((prev) => !prev)}
+        className="sectionBlockWrapper"
+      >
+        <SectionBlock sectionName="PROJECTS" open={showProjects} />
+      </div>
+      {showProjects && <div className="projectSectionGrid">{projectInfo}</div>}
+    </div>
+  );
 }

--- a/src/Components/SectionBlock.js
+++ b/src/Components/SectionBlock.js
@@ -1,15 +1,9 @@
-import React from "react";
-
-export default function SectionBlock(props){
-    return(
-        <div className="sectionBlock" style={props.open ? {backgroundColor: 'transparent', border: '2px solid #FAFAFA'} : {backgroundColor: '#FAFAFA'}}>
-            <span> </span>
-            <h1 className="sectionBlockHeading" style={props.open ? {color: '#FAFAFA'} : {}}>
-                {props.sectionName}
-                </h1>
-            <h1 className="sectionBlockHeading" style={props.open ? {color: '#FAFAFA'} : {}}>
-                {props.open ? '-' : '+'}
-                </h1>
-        </div>
-    )
+export default function SectionBlock({ sectionName, open }) {
+  return (
+    <div className={`sectionBlock ${open ? "sectionBlock--open" : "sectionBlock--closed"}`}>
+      <span> </span>
+      <h1 className="sectionBlockHeading">{sectionName}</h1>
+      <h1 className="sectionBlockHeading">{open ? "-" : "+"}</h1>
+    </div>
+  );
 }

--- a/src/Components/Skills/Skills.js
+++ b/src/Components/Skills/Skills.js
@@ -1,27 +1,31 @@
-import React, {useState} from "react";
+import { useState } from "react";
 import SkillsData from "./SkillsData";
 import SectionBlock from "../SectionBlock";
-import './Skills.css'
+import "./Skills.css";
 
-export default function Skills(){
-    const [showSkills, setShowSkills] = useState(false)
+export default function Skills() {
+  const [showSkills, setShowSkills] = useState(false);
 
-    const skillsInfo = SkillsData.map(skillGroup => {
-        return(
-            <div className="skillGroupBox">
-                <h1>{skillGroup.type}</h1>
-                {skillGroup.details.map(skill => <span className="skill">{skill}</span>)}
-            </div>
-        )
-    })
-    return (
-        <div>
-            <div onClick={()=>setShowSkills(prevState => !prevState)} className="sectionBlockWrapper">
-                <SectionBlock sectionName="SKILLS" open={showSkills}/>
-            </div>
-            <div className="skillsWrapper">
-                {showSkills && skillsInfo}
-            </div>
-        </div>
-    )
+  const skillsInfo = SkillsData.map((skillGroup) => (
+    <div key={skillGroup.type} className="skillGroupBox">
+      <h1>{skillGroup.type}</h1>
+      {skillGroup.details.map((skill) => (
+        <span key={skill} className="skill">
+          {skill}
+        </span>
+      ))}
+    </div>
+  ));
+
+  return (
+    <div>
+      <div
+        onClick={() => setShowSkills((prev) => !prev)}
+        className="sectionBlockWrapper"
+      >
+        <SectionBlock sectionName="SKILLS" open={showSkills} />
+      </div>
+      <div className="skillsWrapper">{showSkills && skillsInfo}</div>
+    </div>
+  );
 }

--- a/src/blogAll.css
+++ b/src/blogAll.css
@@ -59,6 +59,10 @@
     align-items: center;
     margin-bottom: 20px;
 }
+.editSectionLink {
+    color: white;
+    text-decoration: none;
+}
 
 .newButton {
     background-color: #FAFAFA;

--- a/src/dbHelpers.js
+++ b/src/dbHelpers.js
@@ -1,82 +1,47 @@
-
 import { firestore } from "./firebase/config";
-import { collection, getDoc, getDocs, doc, deleteDoc } from "firebase/firestore"
+import { collection, getDoc, getDocs, doc, deleteDoc } from "firebase/firestore";
 
-/*
-Helper function to reduce code written for collection calls to DB
-
-Parameters:
-collectionName - the name of the collection in the db
-stateSetter - the function used to update the state of the data being called (i.e. setExpereince)
-loadingFunction - loading function used when making db calls, typically setLoading for this app
-
-Return:
-Void, should update state with stateSetter function passed in
-
-*/
 const getFirestoreCollection = async (collectionName, stateSetter, loadingFunction) => {
-    try {
-      const dataCol = collection(firestore, collectionName)
-      const dataDocs = await getDocs(dataCol);
-      const data = []
-      dataDocs.forEach((item) => {
-          //onsole.log(doc.data())
-          data.push({
-              id: item.id,
-              ...item.data()
-          })
-      });
-      stateSetter([...data])
-      loadingFunction(false)
-    } catch (error) {
-      throw error.message
-    }
-}
+  try {
+    const dataCol = collection(firestore, collectionName);
+    const dataDocs = await getDocs(dataCol);
+    const data = [];
+    dataDocs.forEach((item) => {
+      data.push({ id: item.id, ...item.data() });
+    });
+    stateSetter([...data]);
+    loadingFunction(false);
+  } catch (error) {
+    throw error.message;
+  }
+};
 
-/*
-Helper function to reduce code written for document calls to DB
-
-Parameters:
-documentId - the document we're trying to get
-stateSetter - the function used to update the state of the data being called (i.e. setExpereince)
-loadingFunction - loading function used when making db calls, typically setLoading for this app
-collectionName - the name of the collection in the db
-
-
-Return:
-Void, should update state with stateSetter function passed in
-
-*/
-const getFirestoreDocument = async(documentId, stateSetter, loadingFunction, collectionName) =>{
-  try{
-    const docRef = doc(firestore, collectionName, documentId)
-    const currDoc = await getDoc(docRef)
-    if(collectionName==="experience"){
+const getFirestoreDocument = async (documentId, stateSetter, loadingFunction, collectionName) => {
+  try {
+    const docRef = doc(firestore, collectionName, documentId);
+    const currDoc = await getDoc(docRef);
+    if (collectionName === "experience") {
       stateSetter({
         ...currDoc.data(),
-        description: currDoc.data().description.join(";")
-      })
+        description: currDoc.data().description.join(";"),
+      });
+    } else {
+      stateSetter(currDoc.data());
     }
-    else{
-      stateSetter(currDoc.data())
-    }
-    loadingFunction(false)
-  }catch(error){
-    throw error.message
+    loadingFunction(false);
+  } catch (error) {
+    throw error.message;
   }
-}
+};
 
-const deleteFirestoreDocument = async(documentId, stateSetter, loadingFunction, collectionName) =>{
-  try{
-      await deleteDoc(doc(firestore, collectionName, documentId))
-      stateSetter(oldData =>{
-          return oldData.filter(curr => curr.id !== documentId)
-      })
-      loadingFunction(false)
+const deleteFirestoreDocument = async (documentId, stateSetter, loadingFunction, collectionName) => {
+  try {
+    await deleteDoc(doc(firestore, collectionName, documentId));
+    stateSetter((oldData) => oldData.filter((curr) => curr.id !== documentId));
+    loadingFunction(false);
+  } catch (error) {
+    throw error.message;
   }
-  catch(error){   
-      throw error.message
-  }
-}
+};
 
-export {getFirestoreCollection, getFirestoreDocument, deleteFirestoreDocument}
+export { getFirestoreCollection, getFirestoreDocument, deleteFirestoreDocument };

--- a/src/edit.css
+++ b/src/edit.css
@@ -22,7 +22,7 @@
 .editButton{
     padding:10px;
     border-radius:none;
-    font-family: Raleway, sans-seriff;
+    font-family: Raleway, sans-serif;
     margin: 0px 5px 0px 5px;
     width:150px;
     font-size:20px;

--- a/src/editDetail.css
+++ b/src/editDetail.css
@@ -61,6 +61,11 @@ button{
     align-items: center;
     flex-direction: column;
 }
+.backLink {
+    color: white;
+    text-decoration: none;
+    margin-bottom: 10px;
+}
 .formBlockWrapper{
     display: flex;
     flex-direction: column;

--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -1,34 +1,28 @@
-// Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app"
-import { getStorage} from "firebase/storage"
-import { getFirestore, collection, addDoc } from "firebase/firestore"
-import { getAuth, 
+import { initializeApp } from "firebase/app";
+import { getStorage } from "firebase/storage";
+import { getFirestore, collection, addDoc } from "firebase/firestore";
+import {
+  getAuth,
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   sendPasswordResetEmail,
-  signOut } from "firebase/auth"
+  signOut,
+} from "firebase/auth";
 
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
-
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
   projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  storageBucket:process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.REACT_APP_FIREBASE_APP_ID,
-  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID
+  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase
 const app = initializeApp(firebaseConfig);
-const auth = getAuth(app)
-const firestore = getFirestore(app)
-const storage = getStorage(app)
-
+const auth = getAuth(app);
+const firestore = getFirestore(app);
+const storage = getStorage(app);
 
 const logInWithEmailAndPassword = async (email, password) => {
   try {
@@ -42,9 +36,8 @@ const logInWithEmailAndPassword = async (email, password) => {
 const registerWithEmailAndPassword = async (name, email, password) => {
   try {
     const res = await createUserWithEmailAndPassword(auth, email, password);
-    const user = res.user;
     await addDoc(collection(firestore, "users"), {
-      uid: user.uid,
+      uid: res.user.uid,
       name,
       authProvider: "local",
       email,
@@ -65,13 +58,14 @@ const sendPasswordReset = async (email) => {
   }
 };
 
+const logout = () => signOut(auth);
 
-const logout = () => {
-  signOut(auth);
+export {
+  auth,
+  firestore,
+  storage,
+  logout,
+  sendPasswordReset,
+  logInWithEmailAndPassword,
+  registerWithEmailAndPassword,
 };
-
-
-
-
-export { auth, firestore, storage, logout, sendPasswordReset, logInWithEmailAndPassword,registerWithEmailAndPassword }
-

--- a/src/pages/BlogAll.js
+++ b/src/pages/BlogAll.js
@@ -1,34 +1,33 @@
-import React, {useState, useEffect} from "react"
+import { useState, useEffect } from "react";
 import Navbar from "../Components/Navbar";
-import '../blogAll.css'
 import Footer from "../Components/Footer/Footer";
 import DataList from "../Components/DataList";
 import { getFirestoreCollection } from "../dbHelpers";
+import "../blogAll.css";
 
+export default function BlogAll() {
+  const [blogData, setBlogData] = useState();
+  const [loading, setLoading] = useState(true);
 
-export default function BlogAll(){
-    const [blogData, setBlogData] = useState()
-    const [loading, setLoading] = useState(true)
+  useEffect(() => {
+    getFirestoreCollection("blog", setBlogData, setLoading);
+  }, []);
 
-    useEffect(() => {
-        getFirestoreCollection("blog", setBlogData, setLoading)
-    }, [])
+  const publishedPosts = blogData ? blogData.filter((post) => post.publishWebsite) : [];
 
-    const publishedPosts = blogData
-        ? blogData.filter(post => post.publishWebsite)
-        : []
-
-    return(
-        <div>
-            <Navbar />
-            <div className="postsWrapperOuter">
-                <div className="postsWrapperInner">
-                    {loading && <p>Loading...</p>}
-                    {!loading && publishedPosts.length === 0 && <p>No posts yet.</p>}
-                    {!loading && publishedPosts.length > 0 && <DataList data={publishedPosts} type="publicBlog"/>}
-                </div> 
-            </div>
-            <Footer />
+  return (
+    <div>
+      <Navbar />
+      <div className="postsWrapperOuter">
+        <div className="postsWrapperInner">
+          {loading && <p>Loading...</p>}
+          {!loading && publishedPosts.length === 0 && <p>No posts yet.</p>}
+          {!loading && publishedPosts.length > 0 && (
+            <DataList data={publishedPosts} type="publicBlog" />
+          )}
         </div>
-    )
+      </div>
+      <Footer />
+    </div>
+  );
 }

--- a/src/pages/BlogDetail.js
+++ b/src/pages/BlogDetail.js
@@ -1,51 +1,58 @@
-import React, {useState, useEffect} from "react"
-import {useParams} from "react-router-dom"
-import Navbar from "../Components/Navbar"
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
-import '../blogDetail.css'
-import Footer from "../Components/Footer/Footer"
-import { collection, query, getDocs, where} from "firebase/firestore"
-import { firestore } from "../firebase/config"
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import Navbar from "../Components/Navbar";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import Footer from "../Components/Footer/Footer";
+import { collection, query, getDocs, where } from "firebase/firestore";
+import { firestore } from "../firebase/config";
+import "../blogDetail.css";
 
+export default function BlogDetail() {
+  const { blogId } = useParams();
+  const [blog, setBlog] = useState();
+  const [loading, setLoading] = useState(true);
 
-export default function BlogDetail(){
-    const {blogId} = useParams()
-    const [blog, setBlog] = useState()
-    const [loading, setLoading] = useState(true)
+  useEffect(() => {
+    const getBlog = async () => {
+      try {
+        const postRef = query(collection(firestore, "blog"), where("slug", "==", blogId));
+        const postDocs = await getDocs(postRef);
+        postDocs.forEach((doc) => setBlog(doc.data()));
+      } catch (error) {
+        console.error(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    getBlog();
+  }, [blogId]);
 
-    useEffect(() =>{
-        const getBlog = async () => {
-            try{
-                const postRef = query(collection(firestore, "blog"), where("slug", "==", blogId))
-                const postDocs = await getDocs(postRef)
-                postDocs.forEach(doc => setBlog(doc.data()))
-                setLoading(false)
-            }
-            catch(error){
-                console.error(error.message)
-                setLoading(false)
-            }
-        }
-        getBlog()
-    },[blogId])
-
-
-    return(
-        <div>
-            <Navbar />
-            {loading && <div className="blogPostWrapperOuter"><p>Loading...</p></div>}
-            {!loading && !blog && <div className="blogPostWrapperOuter"><p>Post not found.</p></div>}
-            {blog && <div className="blogPostWrapperOuter"> 
-                <div className="blogPostWrapperInner">
-                    <h1 className="blogDetailHeading">{blog.title}</h1>
-                    <span className="blogDetailDate">{blog.date}</span>
-                    <div className="blogDetailBody">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{blog.body}</ReactMarkdown>
-                    </div>
-                </div>
-            </div>}
-            <Footer />
+  return (
+    <div>
+      <Navbar />
+      {loading && (
+        <div className="blogPostWrapperOuter">
+          <p>Loading...</p>
         </div>
-    )
+      )}
+      {!loading && !blog && (
+        <div className="blogPostWrapperOuter">
+          <p>Post not found.</p>
+        </div>
+      )}
+      {blog && (
+        <div className="blogPostWrapperOuter">
+          <div className="blogPostWrapperInner">
+            <h1 className="blogDetailHeading">{blog.title}</h1>
+            <span className="blogDetailDate">{blog.date}</span>
+            <div className="blogDetailBody">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{blog.body}</ReactMarkdown>
+            </div>
+          </div>
+        </div>
+      )}
+      <Footer />
+    </div>
+  );
 }

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -1,38 +1,35 @@
-import React, {useEffect} from 'react'
-import {Link, useNavigate} from "react-router-dom"
-import {auth } from '../firebase/config'
+import { useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { auth } from "../firebase/config";
 import { useAuthState } from "react-firebase-hooks/auth";
-import "../edit.css"
+import "../edit.css";
 
+export default function Edit() {
+  const [user, loading] = useAuthState(auth);
+  const navigate = useNavigate();
 
+  useEffect(() => {
+    if (loading) return;
+    if (!user) navigate("/");
+  }, [user, loading, navigate]);
 
-export default function Edit(){
-
-    const [user, loading] = useAuthState(auth)
-    const navigate = useNavigate()
-    useEffect(() => {
-        if (loading) return;
-        if (!user) return navigate("/");
-      }, [user, loading, navigate]);
-
-    return(
-        <div className="pageWrapper">
-            <h1 className="heading">Michael Branconier</h1>
-            <div className="editPageWrapper">
-                <h3 style={{fontSize:'25px'}}>What would you like to edit?</h3>
-                <div className = "linkWrapper">
-                    <Link to="/edit/blog">
-                        <button className="editButton">Blog</button>
-                    </Link>
-                    <Link to="/edit/experience">
-                        <button className="editButton">Experience</button>
-                    </Link>
-                    <Link to="/edit/project">
-                        <button className="editButton">Projects</button>
-                    </Link>
-                </div>
-            </div>
-            
+  return (
+    <div className="pageWrapper">
+      <h1 className="heading">Michael Branconier</h1>
+      <div className="editPageWrapper">
+        <h3>What would you like to edit?</h3>
+        <div className="linkWrapper">
+          <Link to="/edit/blog">
+            <button className="editButton">Blog</button>
+          </Link>
+          <Link to="/edit/experience">
+            <button className="editButton">Experience</button>
+          </Link>
+          <Link to="/edit/project">
+            <button className="editButton">Projects</button>
+          </Link>
         </div>
-    )
+      </div>
+    </div>
+  );
 }

--- a/src/pages/EditBlog.js
+++ b/src/pages/EditBlog.js
@@ -1,44 +1,39 @@
-import React, {useState, useEffect} from 'react'
-import DataList from '../Components/DataList'
-import {useNavigate} from "react-router-dom";
-import {auth } from '../firebase/config'
+import { useState, useEffect } from "react";
+import DataList from "../Components/DataList";
+import { useNavigate } from "react-router-dom";
+import { auth } from "../firebase/config";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { getFirestoreCollection } from '../dbHelpers';
-import { deleteFirestoreDocument } from '../dbHelpers';
+import { getFirestoreCollection, deleteFirestoreDocument } from "../dbHelpers";
 
+export default function EditBlog() {
+  const [, setLoading] = useState(false);
+  const [blogData, setBlogData] = useState();
 
+  const [user, loadingAuth] = useAuthState(auth);
+  const navigate = useNavigate();
 
-export default function EditBlog(){
-    const [, setLoading] = useState()
-    const [blogData, setBlogData] = useState()
+  useEffect(() => {
+    if (loadingAuth) return;
+    if (!user) navigate("/");
+  }, [user, loadingAuth, navigate]);
 
-    const [user, loadingAuth] = useAuthState(auth)
-    const navigate = useNavigate()
-    useEffect(() => {
-        if (loadingAuth) return;
-        if (!user) return navigate("/");
-      }, [user, loadingAuth, navigate]);
+  useEffect(() => {
+    setLoading(true);
+    getFirestoreCollection("blog", setBlogData, setLoading);
+  }, []);
 
-    useEffect(()=>{
-        setLoading(true)
-        getFirestoreCollection("blog",setBlogData,setLoading)
-    }, [])
+  const handleDelete = (event, docId, type) => {
+    event.preventDefault();
+    setLoading(true);
+    deleteFirestoreDocument(docId, setBlogData, setLoading, type);
+  };
 
-    const handleDelete = (event, docId,type) =>{
-        event.preventDefault()
-        setLoading(true)
-        deleteFirestoreDocument(docId, setBlogData, setLoading, type)
-    }
-
-
-    return(
-        <div className = "pageWrapper">
-            <h1 className = "nameHeading">Michael Branconier</h1>
-            <div className="sectionWrapper">
-                <DataList type={"blog"} data ={blogData} deleteFunction={handleDelete}/>
-            </div>
-        </div>
-
-    )
-
+  return (
+    <div className="pageWrapper">
+      <h1 className="nameHeading">Michael Branconier</h1>
+      <div className="sectionWrapper">
+        <DataList type="blog" data={blogData} deleteFunction={handleDelete} />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/EditBlogDetail.js
+++ b/src/pages/EditBlogDetail.js
@@ -1,142 +1,130 @@
-import React, {useState, useEffect} from 'react';
-import { useParams } from 'react-router-dom';
-import '../editDetail.css'
-import {Link, useNavigate} from "react-router-dom";
-import { addDoc, setDoc, collection, doc } from 'firebase/firestore';
-import { firestore, auth } from '../firebase/config';
-import { getFirestoreDocument } from '../dbHelpers';
+import { useState, useEffect } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { addDoc, setDoc, collection, doc } from "firebase/firestore";
+import { firestore, auth } from "../firebase/config";
+import { getFirestoreDocument } from "../dbHelpers";
 import { useAuthState } from "react-firebase-hooks/auth";
+import "../editDetail.css";
 
 function formatDate(date) {
-    const d = new Date(date)
-    return [d.getMonth() + 1, d.getDate(), d.getFullYear()].join("-")
+  const d = new Date(date);
+  return [d.getMonth() + 1, d.getDate(), d.getFullYear()].join("-");
 }
 
-export default function EditBlogDetail(){
-    const {blogId}  = useParams()
-    const [, setLoading] = useState()
-    const [currBlogId, setCurrBlogId] = useState(blogId)
-    const [submitted, setSubmitted] = useState()
+export default function EditBlogDetail() {
+  const { blogId } = useParams();
+  const [, setLoading] = useState(false);
+  const [currBlogId, setCurrBlogId] = useState(blogId);
+  const [submitted, setSubmitted] = useState();
+  const [user, loadingAuth] = useAuthState(auth);
+  const navigate = useNavigate();
 
-    const isNew = currBlogId === "new"
+  const isNew = currBlogId === "new";
 
-    const [blogData, setBlogData] = useState({
-        title: '',
-        body:'',
-        slug:'',
-        date: formatDate(new Date()),
-        publishMedium:false,
-        publishWebsite:false,
-        order: 0
-    })
+  const [blogData, setBlogData] = useState({
+    title: "",
+    body: "",
+    slug: "",
+    date: formatDate(new Date()),
+    publishMedium: false,
+    publishWebsite: false,
+    order: 0,
+  });
 
-    const handleChange = (event)=>{
-        const {name, value, type, checked} = event.target
-        setBlogData(prevData=>{
-            return {
-                ...prevData,
-                [name] : type==="checkbox" ? checked : value
-            }
-        })
+  useEffect(() => {
+    if (loadingAuth) return;
+    if (!user) navigate("/");
+  }, [user, loadingAuth, navigate]);
+
+  useEffect(() => {
+    if (!isNew) {
+      setLoading(true);
+      getFirestoreDocument(currBlogId, setBlogData, setLoading, "blog");
     }
+  }, [currBlogId, isNew]);
 
-    const [user, loadingAuth] = useAuthState(auth)
-    const navigate = useNavigate()
+  const handleChange = ({ target: { name, value, type, checked } }) => {
+    setBlogData((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+  };
 
-    useEffect(() => {
-        if (loadingAuth) return;
-        if (!user) return navigate("/");
-    }, [user, loadingAuth, navigate]);
-
-    useEffect(() =>{
-        if(!isNew){
-            setLoading(true)
-            getFirestoreDocument(currBlogId, setBlogData, setLoading, "blog")
-        }
-    },[currBlogId, isNew])
-
-    const handleSubmit = (event) =>{
-        event.preventDefault()
-        const updateBlog = async() =>{
-            if(isNew){
-                const newData = {
-                    ...blogData,
-                    date: blogData.date || formatDate(new Date())
-                }
-                try{
-                    const blogRef = await addDoc(collection(firestore, "blog"), newData)
-                    setCurrBlogId(blogRef.id)
-                    setSubmitted(new Date().toString())
-                }catch(error){
-                    console.error(error.message)
-                }
-            }
-            else{
-                try{
-                    await setDoc(doc(firestore, "blog", currBlogId), blogData)
-                    setSubmitted(new Date().toString())
-                }catch(error){
-                    console.error(error.message)
-                }
-            }
-        }
-        updateBlog()
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      if (isNew) {
+        const newData = { ...blogData, date: blogData.date || formatDate(new Date()) };
+        const blogRef = await addDoc(collection(firestore, "blog"), newData);
+        setCurrBlogId(blogRef.id);
+      } else {
+        await setDoc(doc(firestore, "blog", currBlogId), blogData);
+      }
+      setSubmitted(new Date().toString());
+    } catch (error) {
+      console.error(error.message);
     }
+  };
 
-    return(
-        <div className="editOuter">
-            <h1 className='nameHeading'>Michael Branconier</h1>
-            <Link to="/edit/blog/" style={{color:'white'}}>Back to Blog</Link>
-            <div className ="editWrapper">
-                <form onSubmit={handleSubmit} className ="formWrapper">
-                    <label>Post Name</label>
-                    <input
-                        type="text"
-                        name="title"
-                        value={blogData.title}
-                        onChange={handleChange}
-                        className="formInputFull"
-                    />
-                    <label>Slug</label>
-                    <input
-                        type="text"
-                        name="slug"
-                        value={blogData.slug}
-                        onChange={handleChange}
-                        className="formInputFull"
-                    />
-                    <label>Date</label>
-                    <input
-                        type="text"
-                        name="date"
-                        value={blogData.date}
-                        onChange={handleChange}
-                        className="formInputFull"
-                        placeholder="M-D-YYYY"
-                    />
-                    <label>Post Body</label>
-                    <span>All text is formatted with <a className="markDownLink" href="https://www.markdownguide.org/basic-syntax/">markdown</a>
-                    </span>
-                    <textarea
-                        name="body"
-                        value={blogData.body}
-                        onChange={handleChange}
-                        className="formBody"
-                    />
-                    <div className="checkboxWrapper">
-                        <input
-                            type="checkbox"
-                            name="publishWebsite"
-                            checked={!!blogData.publishWebsite}
-                            onChange={handleChange}
-                        />
-                        <label className="checkboxLabel" htmlFor="publishWebsite">Publish to Website</label>
-                    </div>
-
-                    {submitted && <span>Post Updated {submitted}</span>}
-                    <button>{isNew ? "Create Post" : "Update Post"}</button>
-                </form>
-            </div>
-        </div>
-    )
+  return (
+    <div className="editOuter">
+      <h1 className="nameHeading">Michael Branconier</h1>
+      <Link to="/edit/blog/" className="backLink">
+        Back to Blog
+      </Link>
+      <div className="editWrapper">
+        <form onSubmit={handleSubmit} className="formWrapper">
+          <label>Post Name</label>
+          <input
+            type="text"
+            name="title"
+            value={blogData.title}
+            onChange={handleChange}
+            className="formInputFull"
+          />
+          <label>Slug</label>
+          <input
+            type="text"
+            name="slug"
+            value={blogData.slug}
+            onChange={handleChange}
+            className="formInputFull"
+          />
+          <label>Date</label>
+          <input
+            type="text"
+            name="date"
+            value={blogData.date}
+            onChange={handleChange}
+            className="formInputFull"
+            placeholder="M-D-YYYY"
+          />
+          <label>Post Body</label>
+          <span>
+            All text is formatted with{" "}
+            <a className="markDownLink" href="https://www.markdownguide.org/basic-syntax/">
+              markdown
+            </a>
+          </span>
+          <textarea
+            name="body"
+            value={blogData.body}
+            onChange={handleChange}
+            className="formBody"
+          />
+          <div className="checkboxWrapper">
+            <input
+              type="checkbox"
+              name="publishWebsite"
+              id="publishWebsite"
+              checked={!!blogData.publishWebsite}
+              onChange={handleChange}
+            />
+            <label className="checkboxLabel" htmlFor="publishWebsite">
+              Publish to Website
+            </label>
+          </div>
+          {submitted && <span>Post Updated {submitted}</span>}
+          <button type="submit">{isNew ? "Create Post" : "Update Post"}</button>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/EditExperience.js
+++ b/src/pages/EditExperience.js
@@ -1,44 +1,42 @@
-import React, {useState, useEffect} from 'react'
-import DataList from '../Components/DataList'
-import "../editSection.css"
-import { getFirestoreCollection,deleteFirestoreDocument } from '../dbHelpers'
-import {useNavigate} from "react-router-dom"
-import {auth } from '../firebase/config'
+import { useState, useEffect } from "react";
+import DataList from "../Components/DataList";
+import { getFirestoreCollection, deleteFirestoreDocument } from "../dbHelpers";
+import { useNavigate } from "react-router-dom";
+import { auth } from "../firebase/config";
 import { useAuthState } from "react-firebase-hooks/auth";
+import "../editSection.css";
 
-export default function EditExperience(){
-    const [expData, setExpData] = useState()
-    const [, setLoading] = useState(false)
-    
-    useEffect(() => {
-        setLoading(true)
-        getFirestoreCollection("experience", setExpData, setLoading)
-      }, [])
-    
-    const handleDelete = (event, docId,type) =>{
-        event.preventDefault()
-        setLoading(true)
-        deleteFirestoreDocument(docId, setExpData, setLoading, type)
-    }
+export default function EditExperience() {
+  const [expData, setExpData] = useState();
+  const [, setLoading] = useState(false);
 
-    const [user, loadingAuth] = useAuthState(auth)
-    const navigate = useNavigate()
+  const [user, loadingAuth] = useAuthState(auth);
+  const navigate = useNavigate();
 
-    useEffect(() => {
-        if (loadingAuth) return ;
-        if (!user) return navigate("/");
-      }, [user, loadingAuth, navigate]);
-    
-    const sortedExpData = expData?.sort((a,b) => {
-        return new Date(b.startDate) - new Date(a.startDate)
-    })
-      
-    return(
-        <div className = "pageWrapper">
-            <h1 className = "nameHeading">Michael Branconier</h1>
-            <div className="sectionWrapper">
-                <DataList type={"experience"} data ={sortedExpData} deleteFunction = {handleDelete}/>
-            </div>
-        </div>
-    )
+  useEffect(() => {
+    if (loadingAuth) return;
+    if (!user) navigate("/");
+  }, [user, loadingAuth, navigate]);
+
+  useEffect(() => {
+    setLoading(true);
+    getFirestoreCollection("experience", setExpData, setLoading);
+  }, []);
+
+  const handleDelete = (event, docId, type) => {
+    event.preventDefault();
+    setLoading(true);
+    deleteFirestoreDocument(docId, setExpData, setLoading, type);
+  };
+
+  const sortedExpData = expData?.sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+
+  return (
+    <div className="pageWrapper">
+      <h1 className="nameHeading">Michael Branconier</h1>
+      <div className="sectionWrapper">
+        <DataList type="experience" data={sortedExpData} deleteFunction={handleDelete} />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/EditExperienceDetail.js
+++ b/src/pages/EditExperienceDetail.js
@@ -1,176 +1,148 @@
-import React, {useState, useEffect} from 'react';
-import { useParams } from 'react-router-dom';
-import {Link, useNavigate} from "react-router-dom";
-import '../editDetail.css'
-import { firestore, auth } from '../firebase/config';
-import { collection, addDoc, setDoc, doc } from 'firebase/firestore';
-import { getFirestoreDocument } from '../dbHelpers';
+import { useState, useEffect } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { firestore, auth } from "../firebase/config";
+import { collection, addDoc, setDoc, doc } from "firebase/firestore";
+import { getFirestoreDocument } from "../dbHelpers";
 import { useAuthState } from "react-firebase-hooks/auth";
+import "../editDetail.css";
 
+export default function EditExperienceDetail() {
+  const { experienceId } = useParams();
+  const [currExperienceId, setCurrExperienceId] = useState(experienceId);
+  const [, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState();
+  const [experienceData, setExperienceData] = useState({
+    position: "",
+    company: "",
+    location: "",
+    startDate: "",
+    endDate: "",
+    description: "",
+    seasonal: false,
+  });
 
+  const [user, loadingAuth] = useAuthState(auth);
+  const navigate = useNavigate();
 
-export default function EditExperienceDetail(){
-    const {experienceId} = useParams()
-    //used to prevent new entries being created after initial doc is saved
-    const [currExperienceId, setCurrExperienceId] = useState(experienceId)
-    const[, setLoading] = useState()
-    const [experienceData, setExperienceData] = useState({
-        position: "",
-        company: "",
-        location: "",
-        startDate: "",
-        endDate: "",
-        description:"",
-        seasonal: false,
-    })
-    const [submitted, setSubmitted] = useState()
-    const handleChange = (event) =>{
-        const {value, name, type, checked} = event.target
-        if(type === 'checkbox') {
-            setExperienceData( prevExpData => {
-                return{
-                    ...prevExpData,
-                    [name]: checked
-                }
-            })
-        } else {
-            setExperienceData( prevExpData => {
-                return{
-                    ...prevExpData,
-                    [name]: value
-                }
-            })
-        }
+  useEffect(() => {
+    if (loadingAuth) return;
+    if (!user) navigate("/");
+  }, [user, loadingAuth, navigate]);
+
+  useEffect(() => {
+    if (experienceId !== "new") {
+      setLoading(true);
+      getFirestoreDocument(currExperienceId, setExperienceData, setLoading, "experience");
     }
-    
-    useEffect(() => {
-        setLoading(true)
-        if(experienceId !== "new") getFirestoreDocument(currExperienceId,setExperienceData, setLoading, "experience")
-    }, [experienceId, currExperienceId])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [experienceId]);
 
-    const handleSubmit =(event) =>{
-        event.preventDefault()
-        const updateExp = async() =>{
-            if(currExperienceId === "new"){
-                //add try and catch
-                const currentDescription = experienceData.description !== "" ?  experienceData.description.split(";") : ""
-                const expRef = await addDoc(
-                    collection(firestore, "experience"),
-                    {
-                        ...experienceData,
-                        description: currentDescription
-                    }
-                )
-                console.log("Document written with ID: ", expRef.id);
-                setCurrExperienceId(expRef.id)
-            }
-            else{
-                try{
-                    const currentDescription = experienceData.description !== "" ?  experienceData.description.split(";") : ""
-                    await setDoc(
-                        doc(firestore, "experience",currExperienceId),
-                        {
-                            ...experienceData,
-                            description: currentDescription
-                        }
-                    )
-                    console.log("Document Updated");
-                }catch(error){
-                    throw error.message
-                }
-            }   
-            setSubmitted(new Date().toString())
-        }
-        updateExp()
+  const handleChange = ({ target: { name, value, type, checked } }) => {
+    setExperienceData((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const description =
+      experienceData.description !== "" ? experienceData.description.split(";") : [];
+    try {
+      if (currExperienceId === "new") {
+        const expRef = await addDoc(collection(firestore, "experience"), {
+          ...experienceData,
+          description,
+        });
+        setCurrExperienceId(expRef.id);
+      } else {
+        await setDoc(doc(firestore, "experience", currExperienceId), {
+          ...experienceData,
+          description,
+        });
+      }
+      setSubmitted(new Date().toString());
+    } catch (error) {
+      throw error.message;
     }
+  };
 
-    const [user, loadingAuth] = useAuthState(auth)
-    const navigate = useNavigate()
-
-    useEffect(() => {
-        if (loadingAuth) return ;
-        if (!user) return navigate("/");
-      }, [user, loadingAuth, navigate]);
-
-    return(
-        <div className="editOuter">
-            <h1 className='nameHeading'>Michael Branconier</h1>
-            <Link to={`/edit/experience/`} style={{color:'white'}}>Back to Experience</Link>
-            <div className ="editWrapper">
-                <form onSubmit={handleSubmit} className ="formWrapper">
-                    <label>Job Position</label>
-                    <input
-                        type = "text"
-                        name = "position"
-                        onChange = {handleChange}
-                        value = {experienceData.position}
-                        className = "formInputFull"
-                    />
-                    <div className = "formHalfWrapper">
-                        <div className = "formBlockWrapper">
-                            <label>Company Name</label>
-                            <input
-                                type = "text"
-                                name = "company"
-                                onChange = {handleChange}
-                                value = {experienceData.company}
-                                className = "formInputHalf"
-                            />
-                        </div>
-                        <div className = "formBlockWrapper">
-                        <label>Location</label>
-                            <input
-                                type = "text"
-                                name = "location"
-                                onChange = {handleChange}
-                                value = {experienceData.location}
-                                className = "formInputHalf"
-                            />
-                        </div>
-                    </div>
-                    <div className = "formHalfWrapper">
-                        <div className = "formBlockWrapper">
-                            <label>Start Date</label>
-                            <input
-                                type = "date"
-                                name = "startDate"
-                                onChange = {handleChange}
-                                value = {experienceData.startDate}
-                                className = "formInputHalf"
-                            />
-                        </div>
-                        <div className = "formBlockWrapper">
-                            <label>End Date</label>
-                                <input
-                                    type = "date"
-                                    name = "endDate"
-                                    onChange = {handleChange}
-                                    value = {experienceData.endDate}
-                                    className = "formInputHalf"
-                                />
-                        </div>
-                    </div>
-                    <label>Seasonal</label>
-                    <input
-                        type = "checkbox"
-                        name = "seasonal"
-                        onChange = {handleChange}
-                        value = {experienceData.seasonal}
-                        className = "formInputHalf"
-                    />
-                    <label>Job Description (Bullets Separated by semicolon)</label>
-                    <textarea 
-                            name="description"
-                            value={experienceData.description}
-                            onChange={handleChange}
-                            className="formBody"
-                    />
-                    {submitted && <span>Submitted {submitted}</span>}
-                    <button>Submit</button>
-                    
-                </form>
+  return (
+    <div className="editOuter">
+      <h1 className="nameHeading">Michael Branconier</h1>
+      <Link to="/edit/experience/" className="backLink">
+        Back to Experience
+      </Link>
+      <div className="editWrapper">
+        <form onSubmit={handleSubmit} className="formWrapper">
+          <label>Job Position</label>
+          <input
+            type="text"
+            name="position"
+            onChange={handleChange}
+            value={experienceData.position}
+            className="formInputFull"
+          />
+          <div className="formHalfWrapper">
+            <div className="formBlockWrapper">
+              <label>Company Name</label>
+              <input
+                type="text"
+                name="company"
+                onChange={handleChange}
+                value={experienceData.company}
+                className="formInputHalf"
+              />
             </div>
-        </div>
-
-    )
+            <div className="formBlockWrapper">
+              <label>Location</label>
+              <input
+                type="text"
+                name="location"
+                onChange={handleChange}
+                value={experienceData.location}
+                className="formInputHalf"
+              />
+            </div>
+          </div>
+          <div className="formHalfWrapper">
+            <div className="formBlockWrapper">
+              <label>Start Date</label>
+              <input
+                type="date"
+                name="startDate"
+                onChange={handleChange}
+                value={experienceData.startDate}
+                className="formInputHalf"
+              />
+            </div>
+            <div className="formBlockWrapper">
+              <label>End Date</label>
+              <input
+                type="date"
+                name="endDate"
+                onChange={handleChange}
+                value={experienceData.endDate}
+                className="formInputHalf"
+              />
+            </div>
+          </div>
+          <label>Seasonal</label>
+          <input
+            type="checkbox"
+            name="seasonal"
+            onChange={handleChange}
+            checked={experienceData.seasonal}
+            className="formInputHalf"
+          />
+          <label>Job Description (bullets separated by semicolon)</label>
+          <textarea
+            name="description"
+            value={experienceData.description}
+            onChange={handleChange}
+            className="formBody"
+          />
+          {submitted && <span>Submitted {submitted}</span>}
+          <button type="submit">Submit</button>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/EditProject.js
+++ b/src/pages/EditProject.js
@@ -1,41 +1,42 @@
-import React, {useEffect, useState} from 'react'
-import DataList from '../Components/DataList'
-import "../editSection.css"
-import {getFirestoreCollection, deleteFirestoreDocument} from "../dbHelpers"
+import { useEffect, useState } from "react";
+import DataList from "../Components/DataList";
+import { getFirestoreCollection, deleteFirestoreDocument } from "../dbHelpers";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { auth } from '../firebase/config';
-import { useNavigate } from 'react-router-dom';
+import { auth } from "../firebase/config";
+import { useNavigate } from "react-router-dom";
+import "../editSection.css";
 
-export default function EditProject(){
-    const [projData, setProjData] = useState()
-    const [, setLoading] = useState(false)
+export default function EditProject() {
+  const [projData, setProjData] = useState();
+  const [, setLoading] = useState(false);
 
-    useEffect(() => {
-        setLoading(true)
-        getFirestoreCollection("project", setProjData, setLoading)
-      }, [])
+  const [user, loadingAuth] = useAuthState(auth);
+  const navigate = useNavigate();
 
-    const handleDelete = (event, docId,type) =>{
-        event.preventDefault()
-        setLoading(true)
-        deleteFirestoreDocument(docId, setProjData, setLoading, type)
-    }
+  useEffect(() => {
+    if (loadingAuth) return;
+    if (!user) navigate("/");
+  }, [user, loadingAuth, navigate]);
 
-    const [user, loadingAuth] = useAuthState(auth)
-    const navigate = useNavigate()
-    useEffect(() => {
-        if (loadingAuth) return ;
-        if (!user) return navigate("/");
-      }, [user, loadingAuth, navigate]);
+  useEffect(() => {
+    setLoading(true);
+    getFirestoreCollection("project", setProjData, setLoading);
+  }, []);
 
-    const sortedProjData = projData?.sort((a,b) => a.order - b.order)
+  const handleDelete = (event, docId, type) => {
+    event.preventDefault();
+    setLoading(true);
+    deleteFirestoreDocument(docId, setProjData, setLoading, type);
+  };
 
-    return (
-        <div className = "pageWrapper">
-            <h1 className = "nameHeading">Michael Branconier</h1>
-            <div className="sectionWrapper">
-                <DataList type={"project"} data ={sortedProjData} deleteFunction={handleDelete}/>
-            </div>
-        </div>
-    )
+  const sortedProjData = projData?.sort((a, b) => a.order - b.order);
+
+  return (
+    <div className="pageWrapper">
+      <h1 className="nameHeading">Michael Branconier</h1>
+      <div className="sectionWrapper">
+        <DataList type="project" data={sortedProjData} deleteFunction={handleDelete} />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/EditProjectDetail.js
+++ b/src/pages/EditProjectDetail.js
@@ -1,137 +1,124 @@
-import React, {useEffect, useState} from 'react';
-import { useParams } from 'react-router-dom';
-import {Link,useNavigate} from "react-router-dom";
-import '../editDetail.css'
-import { firestore,auth } from '../firebase/config';
-import { collection, addDoc, setDoc, doc } from 'firebase/firestore';
-import { getFirestoreDocument } from '../dbHelpers';
-import { useAuthState } from 'react-firebase-hooks/auth';
-import { FormControlLabel, Switch } from '@mui/material';
+import { useEffect, useState } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { firestore, auth } from "../firebase/config";
+import { collection, addDoc, setDoc, doc } from "firebase/firestore";
+import { getFirestoreDocument } from "../dbHelpers";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { FormControlLabel, Switch } from "@mui/material";
+import "../editDetail.css";
 
-export default function EditProjectDetail(){
-    const {projectId} = useParams()
-    const [submitted, setSubmitted] = useState()
-    const [currProjId, setCurrProjId] = useState(projectId)
-    const [, setLoading] = useState()
-    const [projectData, setProjectData] = useState({
-        name: "",
-        description:"",
-        link: "",
-        githubLink:"",
-        skills:[],
-        hidden: false,
-        updatedAt: new Date(),
-        // Remove the order field from here
-    })
+export default function EditProjectDetail() {
+  const { projectId } = useParams();
+  const [submitted, setSubmitted] = useState();
+  const [currProjId, setCurrProjId] = useState(projectId);
+  const [, setLoading] = useState(false);
+  const [projectData, setProjectData] = useState({
+    name: "",
+    description: "",
+    link: "",
+    githubLink: "",
+    skills: [],
+    hidden: false,
+    updatedAt: new Date(),
+  });
 
-    useEffect(()=>{
-        setLoading(true)
-        if(currProjId !== "new") getFirestoreDocument(currProjId,setProjectData, setLoading,"project")
-    }, [currProjId])
+  const [user, loadingAuth] = useAuthState(auth);
+  const navigate = useNavigate();
 
-    const handleChange = (event) =>{
-        const {value, name} = event.target
-        setProjectData(prevProjData => {
-            return {
-                ...prevProjData,
-                [name]: name === "skills" ? value.split(",") : value
-            }
-        })
+  useEffect(() => {
+    if (loadingAuth) return;
+    if (!user) navigate("/");
+  }, [user, loadingAuth, navigate]);
+
+  useEffect(() => {
+    setLoading(true);
+    if (currProjId !== "new") getFirestoreDocument(currProjId, setProjectData, setLoading, "project");
+  }, [currProjId]);
+
+  const handleChange = ({ target: { name, value } }) => {
+    setProjectData((prev) => ({
+      ...prev,
+      [name]: name === "skills" ? value.split(",") : value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      if (currProjId === "new") {
+        const projRef = await addDoc(collection(firestore, "project"), projectData);
+        setCurrProjId(projRef.id);
+      } else {
+        await setDoc(doc(firestore, "project", currProjId), projectData);
+      }
+      setSubmitted(new Date().toString());
+    } catch (error) {
+      throw error.message;
     }
+  };
 
-    const [user, loadingAuth] = useAuthState(auth)
-    const navigate = useNavigate()
-    useEffect(() => {
-        if (loadingAuth) return ;
-        if (!user) return navigate("/");
-      }, [user, loadingAuth, navigate]);
-
-    const handleSubmit =(event) =>{
-        event.preventDefault()
-        const updateProj = async() =>{
-            if(currProjId === "new"){
-                try{
-                    const projRef = await addDoc(collection(firestore, "project"),projectData)
-                    console.log("Document written with ID: ", projRef.id);
-                    setCurrProjId(projRef.id)
-                }catch(error){
-                    throw error.message
-                }
+  return (
+    <div className="editOuter">
+      <h1 className="nameHeading">Michael Branconier</h1>
+      <Link to="/edit/project/" className="backLink">
+        Back to Projects
+      </Link>
+      <div className="editWrapper">
+        <form onSubmit={handleSubmit} className="formWrapper">
+          <label>Project Name</label>
+          <input
+            type="text"
+            name="name"
+            onChange={handleChange}
+            value={projectData.name}
+            className="formInputFull"
+          />
+          <label>Project Description</label>
+          <textarea
+            name="description"
+            onChange={handleChange}
+            value={projectData.description}
+            className="formInputFull"
+            placeholder="Keep brief"
+          />
+          <label>Project Link</label>
+          <input
+            type="text"
+            name="link"
+            onChange={handleChange}
+            value={projectData.link}
+            className="formInputFull"
+          />
+          <label>Github Link</label>
+          <input
+            type="text"
+            name="githubLink"
+            onChange={handleChange}
+            value={projectData.githubLink}
+            className="formInputFull"
+          />
+          <label>Tags</label>
+          <input
+            type="text"
+            name="skills"
+            onChange={handleChange}
+            value={projectData.skills}
+            className="formInputFull"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={projectData.hidden || false}
+                onChange={(e) => setProjectData((prev) => ({ ...prev, hidden: e.target.checked }))}
+                name="hidden"
+              />
             }
-            else{
-                try{
-                    await setDoc(doc(firestore, "project",currProjId),projectData)
-                    console.log(projectData)
-                    console.log("Document Updated");
-                }catch(error){
-                    throw error.message
-                }
-            }   
-            setSubmitted(new Date().toString())
-        }
-        updateProj()
-    }
-    return (
-        <div className="editOuter">
-            <h1 className='nameHeading'>Michael Branconier</h1>
-            <Link to={`/edit/project/`} style={{color:'white'}}>Back to Projects</Link>
-            <div className ="editWrapper">
-                <form onSubmit={handleSubmit} className ="formWrapper">
-                    <label>Project Name</label>
-                    <input
-                        type = "text"
-                        name = "name"
-                        onChange = {handleChange}
-                        value = {projectData.name}
-                        className = "formInputFull"
-                    />
-                    <label>Project Description</label>
-                    <textarea
-                        name = "description"
-                        onChange = {handleChange}
-                        value = {projectData.description}
-                        className = "formInputFull"
-                        placeholder='Keep brief'
-                    />
-                    <label>Project Link</label>
-                    <input
-                        type = "text"
-                        name = "link"
-                        onChange = {handleChange}
-                        value = {projectData.link}
-                        className = "formInputFull"
-                    />              
-                    <label>Github Link</label>
-                    <input
-                        type = "text"
-                        name = "githubLink"
-                        onChange = {handleChange}
-                        value = {projectData.githubLink}
-                        className = "formInputFull"
-                    /> 
-                    <label>Tags</label>
-                    <input
-                        type = "text"
-                        name = "skills"
-                        onChange = {handleChange}
-                        value = {projectData.skills}
-                        className = "formInputFull"
-                    /> 
-                    <FormControlLabel
-                        control={
-                            <Switch
-                                checked={projectData.hidden || false}
-                                onChange={(e) => setProjectData({...projectData, hidden: e.target.checked})}
-                                name="hidden"
-                            />
-                        }
-                        label="Hidden"
-                    />
-                    
-                    {submitted && <span>Updated {submitted}</span>}
-                    <button>Submit</button>
-                </form>
-            </div>
-        </div>
-    )
+            label="Hidden"
+          />
+          {submitted && <span>Updated {submitted}</span>}
+          <button type="submit">Submit</button>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,3 @@
-import React from "react";
 import Navbar from "../Components/Navbar";
 import About from "../Components/About/About";
 import Education from "../Components/Education/Education";
@@ -9,8 +8,8 @@ import Footer from "../Components/Footer/Footer";
 
 export default function Home() {
   return (
-    <div className="">
-      <Navbar/>
+    <div>
+      <Navbar />
       <div className="homeWrapper">
         <About />
         <Projects />
@@ -20,6 +19,5 @@ export default function Home() {
         <Footer />
       </div>
     </div>
-
   );
 }

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,56 +1,48 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { auth,logInWithEmailAndPassword } from "../firebase/config";
+import { auth, logInWithEmailAndPassword } from "../firebase/config";
 import { useAuthState } from "react-firebase-hooks/auth";
+import "../login.css";
 
-import "../login.css"
-export default function Login(){
-    const [username, setUsername] = useState("")
-    const [password, setPassword] = useState("")
-    const [user, loading] = useAuthState(auth);
-    const navigate = useNavigate()
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [user, loading] = useAuthState(auth);
+  const navigate = useNavigate();
 
-    useEffect(()=>{
-        if(user) navigate("/edit")
-    }, [user, loading, navigate])
+  useEffect(() => {
+    if (user) navigate("/edit");
+  }, [user, loading, navigate]);
 
-    const handleChange = (event) =>{
-        const {name, value} = event.target
-        if(name==='username'){
-            setUsername(value)
-        } 
-        else {
-            setPassword(value)
-        }
-    }
-    const handleSubmit = (event) =>{
-        event.preventDefault()
-        //submit password and username
-    }
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    logInWithEmailAndPassword(email, password);
+  };
 
-    return(
-        <div className="loginWrapper">
-            <form className="loginForm" onSubmit={handleSubmit}>
-            <h1 className="michaelBranconier">Michael Branconier</h1>
-                <input 
-                    type="text" 
-                    name="username"
-                    placeholder="Username"
-                    className="loginInput"
-                    value ={username}
-                    onChange={handleChange}
-                 />
-                <input 
-                    type="password"
-                    name="password"
-                    placeholder="Password"
-                    className="loginInput"
-                    value={password}
-                    onChange={handleChange}
-                 /> 
-                 <button onClick={() => logInWithEmailAndPassword(username,password)} className="submitButton">Go</button>
-
-            </form>
-        </div>
-    )
+  return (
+    <div className="loginWrapper">
+      <form className="loginForm" onSubmit={handleSubmit}>
+        <h1 className="michaelBranconier">Michael Branconier</h1>
+        <input
+          type="email"
+          name="email"
+          placeholder="Email"
+          className="loginInput"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          name="password"
+          placeholder="Password"
+          className="loginInput"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit" className="submitButton">
+          Go
+        </button>
+      </form>
+    </div>
+  );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,6 +40,16 @@ body{
     border-radius: 10px;
     padding: 18px;
 }
+.sectionBlock--open {
+    background-color: transparent;
+    border: 2px solid #FAFAFA;
+}
+.sectionBlock--open .sectionBlockHeading {
+    color: #FAFAFA;
+}
+.sectionBlock--closed {
+    background-color: #FAFAFA;
+}
 .homeWrapper{
     padding: 40px 100px;
     max-width: 1200px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Cleaned up the code style across every file — same features and logic, just written more cleanly.

### React / JSX
- Removed `import React from 'react'` everywhere (unnecessary since React 17's JSX transform)
- Removed unused `import "./App.css"` and the redundant `<div>` wrapper wrapping `<Routes>` in `App.js`
- Removed invalid `exact` prop from routes (not a thing in React Router v6)
- Fixed empty `className=""` in `Home.js`

### Dependencies
- Dropped `moment.js` — replaced the one date formatting call in `Experience.js` with native `Intl.DateTimeFormat`

### Component patterns
- Destructured props directly in function signatures (`DataList`, `SectionBlock`)
- Replaced `SectionBlock`'s inline style toggling with BEM CSS modifier classes (`sectionBlock--open` / `sectionBlock--closed`)
- Replaced all `style={{color:'white'}}` inline styles on link elements with `.backLink` and `.editSectionLink` CSS classes
- Refactored `Footer` to a data-driven `LINKS` array instead of four copy-paste `<a>` tags

### Form handling
- Unified `handleChange` into a single expression in `Login`, `EditBlogDetail`, `EditProjectDetail`, and `EditExperienceDetail` (previously `EditExperienceDetail` had a split if/else for checkbox vs. text)
- Wired `Login`'s `handleSubmit` to actually call `logInWithEmailAndPassword` (it was a noop; the call lived on the button's `onClick` instead)
- Changed login email field `type` from `text` to `email` and renamed state from `username` to `email`
- Fixed `seasonal` checkbox in `EditExperienceDetail`: was using `value=` instead of `checked=`
- Added `type="submit"` to submit buttons

### Bug / logic fixes
- Fixed `EditExperienceDetail` `useEffect` dependency array — was listing both `experienceId` and `currExperienceId`, causing double-fetches on save; now only depends on the URL param
- Added missing `try/catch` around the "new entry" path in `EditExperienceDetail`
- Refactored `BlogDetail` to use `finally` for `setLoading(false)` so it always clears regardless of error
- Fixed missing `key` props in `Skills.js` map calls

### Cleanup
- Removed stale `console.log` calls left in `EditProjectDetail` and `EditExperienceDetail`
- Removed stale `// Remove the order field from here` comment in `EditProjectDetail`
- Removed the commented-out `//onsole.log` line in `dbHelpers.js`
- Consolidated two separate `dbHelpers` imports into one in `EditBlog.js`
- Removed boilerplate Firebase `// TODO:` and auto-generated comments from `firebase/config.js`
- Removed the `h3` inline `fontSize` style in `Edit.js`

### Typo fixes
- `showExpereince` → `showExperience` in `Experience.js`
- `acheivement` → `achievement` in `Education.js` and `Education.css`
- `sans-seriff` → `sans-serif` in `edit.css`

### Formatting
- Consistent JSX attribute spacing (removed extra spaces like `name = "position"`)
- Consistent import ordering and trailing semicolons throughout

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fbdc440-61f7-4778-b224-f7998724c85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fbdc440-61f7-4778-b224-f7998724c85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

